### PR TITLE
Support NSAttributedString on label of pie chart

### DIFF
--- a/PieCharts/Core/Slice/PieSliceLayer.swift
+++ b/PieCharts/Core/Slice/PieSliceLayer.swift
@@ -122,6 +122,13 @@ open class PieSliceLayer: CALayer, CAAnimationDelegate {
         //rotate(angle: referenceAngle)
         presentStartAngle(angle: startAngle, animated: animated)
         presentEndAngle(angle: endAngle, animated: animated)
+        
+                
+        if !animated {
+            guard let data = sliceData else {return}
+            sliceDelegate?.onStartAnimation(slice: PieSlice(data: data, view: self))
+            sliceDelegate?.onEndAnimation(slice: PieSlice(data: data, view: self))
+        }
     }
     
     func rotate(angle: CGFloat) {

--- a/PieCharts/Layer/Impl/Common/PieChartLabelSettings.swift
+++ b/PieCharts/Layer/Impl/Common/PieChartLabelSettings.swift
@@ -9,12 +9,19 @@
 import UIKit
 
 public class PieChartLabelSettings {
+    // String type checker - check type to use attributed string
+    public enum `Type` {
+        case plain
+        case attributed
+    }
     
+    public var type: Type = .plain
     public var textColor: UIColor = UIColor.black
     public var bgColor: UIColor = UIColor.clear
     public var font: UIFont = UIFont.boldSystemFont(ofSize: 20)
     
-    public var textGenerator: (PieSlice) -> String = {"\($0.data.model.value)"}
+    public var textGenerator: (PieSlice) -> String = { "\($0.data.model.value)" }
+    public var attributedTextGenerator: (PieSlice) -> NSAttributedString = { NSAttributedString(string: "\($0.data.model.value)") }
     
     // Optional custom label - when this is set presentations settings (textColor, etc.) are ignored
     public var labelGenerator: ((PieSlice) -> UILabel)?

--- a/PieCharts/Layer/Impl/LineText/PieLineTextLayer.swift
+++ b/PieCharts/Layer/Impl/LineText/PieLineTextLayer.swift
@@ -85,7 +85,13 @@ open class PieLineTextLayer: PieChartLayer {
             return label
             }()
         
-        label.text = settings.label.textGenerator(slice)
+        switch settings.label.type {
+        case .plain:
+            label.text = settings.label.textGenerator(slice)
+        case .attributed:
+            label.attributedText = settings.label.attributedTextGenerator(slice)
+        }
+        
         label.sizeToFit()
         label.frame.origin = CGPoint(x: referencePoint.x - (isRightSide ? 0 : label.frame.width) + ((isRightSide ? 1 : -1) * settings.labelOffset), y: referencePoint.y - label.frame.height / 2)
         

--- a/PieCharts/Layer/Impl/PlainText/PiePlainTextLayer.swift
+++ b/PieCharts/Layer/Impl/PlainText/PiePlainTextLayer.swift
@@ -42,14 +42,26 @@ open class PiePlainTextLayer: PieChartLayer {
             return label
             }()
         
-        let text = settings.label.textGenerator(slice)
-        let size = (text as NSString).size(attributes: [NSFontAttributeName: settings.label.font])
+        let size: CGSize
+        
+        switch settings.label.type {
+        case .plain:
+            let text = settings.label.textGenerator(slice)
+            size = (text as NSString).size(attributes: [NSFontAttributeName: settings.label.font])
+        case .attributed:
+            size = settings.label.attributedTextGenerator(slice).size()
+        }
         
         let center = settings.viewRadius.map{slice.view.midPoint(radius: $0)} ?? slice.view.arcCenter
         let availableSize = CGSize(width: slice.view.maxRectWidth(center: center, height: size.height), height: size.height)
         
         if !settings.hideOnOverflow || availableSize.contains(size) {
-            label.text = text
+            switch settings.label.type {
+            case .plain:
+                label.text = settings.label.textGenerator(slice)
+            case .attributed:
+                label.attributedText = settings.label.attributedTextGenerator(slice)
+            }
             label.sizeToFit()
         } else {
             onNotEnoughSpace?(label, availableSize)

--- a/PieCharts/Model/PieSliceModel.swift
+++ b/PieCharts/Model/PieSliceModel.swift
@@ -10,10 +10,12 @@ import UIKit
 
 public class PieSliceModel: CustomDebugStringConvertible {
     
+    public let name: String?
     public let value: Double
     public let color: UIColor
     
-    public init(value: Double, color: UIColor) {
+    public init(name: String? = nil, value: Double, color: UIColor) {
+        self.name = name
         self.value = value
         self.color = color
     }


### PR DESCRIPTION
I want to using label with attributed string with name (issue #8).
So, the following tasks were carried out :

1. add 'name' property on PieSliceModel to identify as text
2. support NSAttributedString to use label better without modifying labelGenerator on PieChartLabelSettings.swift


you can create slice model as:
`
PieSliceModel(value: 2, color: colors[2]) // previous
`
or
`
PieSliceModel(name: "fff", value: 2, color: colors[0]) // this time
`

and you can use attributedText as:

        let categoryAttr = [
            NSFontAttributeName: UIFont.systemFont(ofSize: 8, weight: UIFontWeightLight),
            NSForegroundColorAttributeName: UIColor.blue
        ]

        let percentageAttr = [
            NSFontAttributeName: UIFont.systemFont(ofSize: 8),
            NSForegroundColorAttributeName: UIColor.black
        ]

        textLayerSettings.label.type = .attributed
        textLayerSettings.label.attributedTextGenerator = {slice in
            let categoryString = NSMutableAttributedString(string: slice.data.model.name ?? "", attributes: categoryAttr)
            let percentageString = NSMutableAttributedString(string:
                formatter.string(from: slice.data.percentage * 100 as NSNumber).map{"\($0)%"} ?? "", attributes: percentageAttr)
            categoryString.append(percentageString)
            
            return categoryString
        }

without textGenerator. 

Thank you!