### PR TITLE
Long time since a new release and important changes has been made

### DIFF
--- a/PieCharts.podspec
+++ b/PieCharts.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name = "PieCharts"
-  s.version = "0.0.4"
+  s.version = "0.0.5"
   s.summary = "Easy to use and highly customizable pie charts library for iOS"
   s.homepage = "https://github.com/i-schuetz/PieCharts"
   s.license = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
   s.authors = "Ivan Schuetz"
   s.ios.deployment_target = "8.0"
-  s.source = { :git => "https://github.com/i-schuetz/PieCharts.git", :tag => '0.0.4'}
+  s.source = { :git => "https://github.com/i-schuetz/PieCharts.git", :tag => s.version }
   s.source_files = 'PieCharts/*.swift', 'PieCharts/**/*.swift'
   s.frameworks = "Foundation", "UIKit", "CoreGraphics"
 end


### PR DESCRIPTION
I needed the referenceAngle to be public but Pod was still at tag '0.0.4' which didnt have the change. So I made a fork and updated the podspec.version. You just need to push a new tag '0.0.5' I think.