### PR TITLE
Updated PieChart - overridden a function layoutSubviews

### DIFF
--- a/PieCharts/Core/Chart/PieChart.swift
+++ b/PieCharts/Core/Chart/PieChart.swift
@@ -242,6 +242,11 @@ import UIKit
         
         self.models = models
     }
+    
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        container.frame = bounds
+    }
 }
 
 extension PieChart: PieSliceDelegate {


### PR DESCRIPTION
It's needed so that when the Class needs layout updating, the chart will just call setNeedsLayout(), and the container will adjust to the bounds at layoutSubviews

